### PR TITLE
remove bower install and grunt build from bootstrap script

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -29,11 +29,11 @@ which sass 2>&1 >/dev/null || {
 echo -e '\n== Installing project dependencies =='
 echo -e '\n== Installing npm dependencies =='
 npm install
-echo -e '\n== Installing bower dependencies =='
-bower install
+#echo -e '\n== Installing bower dependencies =='
+#bower install
 
-echo -e '\n== Running grunt build =='
-grunt build
+#echo -e '\n== Running grunt build =='
+#grunt build
 
 echo -e '\n== Setup finished =='
 echo 'Run `grunt watch` to continuously watch for file changes.'


### PR DESCRIPTION
bower install and grunt build are running as post-install from npm install from now on