### PR TITLE
iss#492 Replaced the username label with epost label for login form 

### DIFF
--- a/src/app/common/templates/signin.html
+++ b/src/app/common/templates/signin.html
@@ -3,10 +3,10 @@
         <h1>{{'login.title' | translate}}</h1>
         <form name="form" novalidate ng-submit="ctrl.process()">
             <div class="material-input">
-                <validation2 form="form" field="email" errormsg="login.form.username.validation">
+                <validation2 form="form" field="email" errormsg="user.form.email.validation">
                     <div class="group">
                         <input type="email" name="email" required ng-model="ctrl.data.email" ng-keyup="form.email.error_detail = undefined">
-                        <label>{{'login.form.username' | translate}}</label>
+                        <label>{{'user.form.email' | translate}}</label>
                     </div>
                 </validation2>
 


### PR DESCRIPTION
there is no actually any translation for login.form.email (field label) and login.form.email.validation (error message), there is only for username.
The solution: I can reuse user.form.email it has right translation, but then for error message will be 'you need to enter a valid email' instead of 'Epost missing'