### PR TITLE
Fix "Show all" jobs arrow alignment

### DIFF
--- a/src/scss/layouts/_home.scss
+++ b/src/scss/layouts/_home.scss
@@ -233,7 +233,7 @@
   display: inline-block;
   position: absolute;
   right: 20px;
-  margin-top: 5px;
+  margin-top: 2px;
   font-size: 0.7em;
   text-transform: uppercase;
   text-decoration: none;
@@ -242,6 +242,7 @@
     text-decoration: none;
     span {
       display: none;
+      vertical-align: middle;
     }
   }
   a:after {
@@ -249,7 +250,7 @@
     content: '\e80a';
     font-size: 1.4em;
     vertical-align: middle;
-    margin-left: 4px;
+    margin-left: 6px;
   }
 }
 


### PR DESCRIPTION
This is a small thing that have been annoying me. 

Before:
<img width="108" alt="screen shot 2016-06-20 at 22 59 17" src="https://cloud.githubusercontent.com/assets/1674417/16210120/ac57befc-373a-11e6-9772-dd750a4a9537.png">

After:
<img width="138" alt="screen shot 2016-06-20 at 22 58 26" src="https://cloud.githubusercontent.com/assets/1674417/16210094/8db6fa08-373a-11e6-9d09-316bdb78f210.png">
