### PR TITLE
Fix chat page sticky form

### DIFF
--- a/src/scss/layouts/_job.scss
+++ b/src/scss/layouts/_job.scss
@@ -1582,6 +1582,7 @@ job-body, job-comment {
 
 .chat-box form {
   background-color: $white;
+  max-width: 1024px;
 }
 
 .comment-form-box {


### PR DESCRIPTION
The sticky form was breaking outside of the 1024 max width. This will fix that issue.

<img width="1208" alt="screen shot 2016-07-20 at 13 11 08" src="https://cloud.githubusercontent.com/assets/1674417/16984622/7f7c31a8-4e7b-11e6-8bf7-8b5ad63ff313.png">
