### PR TITLE
Run script/bootstrap in script/server

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -303,7 +303,7 @@ module.exports = function (grunt) {
                     // And more servers here
                 ],
                 options: {
-                    port: process.env.SERVER_PORT || 9000,
+                    port: process.env.JAF_SERVER_PORT || 9000,
                     hostname: '0.0.0.0',
                     base: '<%= build_dir %>',
                     open: false,

--- a/script/server
+++ b/script/server
@@ -4,5 +4,10 @@ IFS=$'\n\t'
 
 cd "$(dirname "$0")/.."
 
-echo -e '\n== Starting server =='
+script/bootstrap
+
+# Set server port
+export JAF_SERVER_PORT=${1:-9000}
+
+echo -e "\n== Starting server on port $JAF_SERVER_PORT =="
 grunt watch


### PR DESCRIPTION
__Problem__

If you have outdated dependencies:

* The server still started with no errors 
* When a page is loaded an init errors are thrown and no page is displayed

__Solution__

Run `script/bootstrap` before starting the grunt server.