### PR TITLE
Fix #673: rename property to avoid collision

### DIFF
--- a/src/app/common/controllers/JobCtrl.js
+++ b/src/app/common/controllers/JobCtrl.js
@@ -693,10 +693,10 @@
                     });
                 };
 
-                $scope.comments = [];
+                $scope.commentss = {};
                 this.getComments = function (job_id) {
-                    $scope.comments = commentService.getComments('jobs', job_id, 'owner,owner.user-images');
-                    $scope.comments.$promise.then(function (response) {
+                    $scope.commentss = commentService.getComments('jobs', job_id, 'owner,owner.user-images');
+                    $scope.commentss.$promise.then(function (response) {
                         var deferd = $q.defer();
                         $scope.comments = [];
                         var curr_user_id = '0';
@@ -783,7 +783,7 @@
 
                             $scope.comments.push(obj);
                         });
-                        deferd.resolve($scope.comments);
+                        deferd.resolve($scope.commentss);
                         return deferd.promise;
                     });
                 };


### PR DESCRIPTION
`$scope.comments` was declared twice. 

The return value of `commentService.getComments` is usually set to `$scope.commentss` and the finial comment array is set to `$scope.comments`. In this case both were set to `$scope.comments`.