### PR TITLE
Fix #710: Add input hint

### DIFF
--- a/config/translations/en.json
+++ b/config/translations/en.json
@@ -152,6 +152,7 @@
     "assignment.form.hours.validation": "Number of hours missing",
     "assignment.form.rate.validation": "Wage details missing",
     "assignment.form.zip.validation": "You need to enter a post code",
+    "assignment.form.short_description.hint": "Summary to be shown in the job list",
     "assignment.rate.description": "We have three wage levels: Minimum SEK105/hr. excluding VAT, Recommended SEK115/hr. excluding VAT, and Generous SEK125/hr. excluding VAT.",
     "assignment.rate.low": "minimum",
     "assignment.rate.medium": "Recommended",

--- a/src/app/common/directives/Validation.js
+++ b/src/app/common/directives/Validation.js
@@ -18,6 +18,7 @@ angular
         scope: {
             field: '@',
             errormsg: '@',
+            hint: '@',
             form: '='
         },
         templateUrl: 'common/templates/directives/validation2.html',

--- a/src/app/common/templates/directives/validation2.html
+++ b/src/app/common/templates/directives/validation2.html
@@ -7,4 +7,5 @@
         <span class="text-danger" ng-show="form[field].$invalid && form[field].$touched">{{errormsg | translate}}</span>
         <span class="text-danger return" ng-show="form[field].error_detail">{{form[field].error_detail}}</span>
     </div>
+    <span class="form-hint" ng-if="hint">{{hint | translate}}</span>
 </div>

--- a/src/app/common/templates/new-job.html
+++ b/src/app/common/templates/new-job.html
@@ -30,7 +30,7 @@
             </div>
 
             <div class="material-input">
-                <validation2 form="form" field="short_description" errormsg="assignment.form.short_description.validation">
+                <validation2 form="form" field="short_description" errormsg="assignment.form.short_description.validation" hint="assignment.form.short_description.hint">
                     <div class="group">
                         <textarea name="short_description" ng-maxlength="150" msd-elastic
                                   ng-model="ctrl.model.data.attributes.short_description"

--- a/src/scss/components/_form.scss
+++ b/src/scss/components/_form.scss
@@ -38,7 +38,19 @@ label {
 }
 
 .form-error-detail {
-  margin-top: -22px;
+  font-size: 0.9em;
+  text-align: left;
+  line-height: 1.3em;
+
+  &,
+  &.ng-hide + .form-hint {
+    margin-top: -20px;
+  }
+}
+
+.form-hint {
+  margin: 4px 0 0;
+  display: block;
   font-size: 0.9em;
   text-align: left;
   line-height: 1.3em;


### PR DESCRIPTION
Added hint option to the validation component and hint text for short description. Not sure of what the hint should say though. 

<img width="574" alt="screen shot 2016-08-09 at 16 30 32" src="https://cloud.githubusercontent.com/assets/1674417/17520130/d64fb68e-5e4e-11e6-9db5-45e6de324752.png">
<img width="585" alt="screen shot 2016-08-09 at 16 30 19" src="https://cloud.githubusercontent.com/assets/1674417/17520129/d64e6fea-5e4e-11e6-88b8-50f59de5c7dc.png">

I also made the margin between input and error-message/hint 2px larger to make it feel less cramped. 
